### PR TITLE
Fix: the connection test in case ports are used

### DIFF
--- a/Scripts/munki_enroll.sh
+++ b/Scripts/munki_enroll.sh
@@ -12,7 +12,7 @@ if [ ! -z "$IDENTIFIER" ]; then
 	SUBMITURL="http://localhost:8888/munki/munki-enroll/enroll.php"
 
 	# Test the connection to the server
-	SHORTURL=$(echo "$SUBMITURL" | awk -F/ '{print $3}')
+	SHORTURL=$(echo "$SUBMITURL" | awk -F/ '{print $3}' | awk -F: '{print $1}')
 	PINGTEST=$(ping -o "$SHORTURL" | grep "64 bytes")
 
 	if [ ! -z "$PINGTEST" ]; then


### PR DESCRIPTION
ping cannot resolve any URL if any port is specified. To fix this we can simply awk the first part of the SHORTURL, which is always the needed URL to perform the ping.

ping.test:8080 => ping.test
ping.test => ping.test