### PR TITLE
Update CFBinaryPropertyList.php

### DIFF
--- a/munki-enroll/cfpropertylist-2.0.1/CFBinaryPropertyList.php
+++ b/munki-enroll/cfpropertylist-2.0.1/CFBinaryPropertyList.php
@@ -801,7 +801,7 @@ abstract class CFBinaryPropertyList {
    */
   protected static function binaryStrlen($val) {
     for($i=0;$i<strlen($val);++$i) {
-      if(ord($val{$i}) >= 128) {
+      if(ord($val[$i]) >= 128) {
         $val = self::convertCharset($val, 'UTF-8', 'UTF-16BE');
         return strlen($val);
       }
@@ -824,7 +824,7 @@ abstract class CFBinaryPropertyList {
       $utf16 = false;
 
       for($i=0;$i<strlen($val);++$i) {
-        if(ord($val{$i}) >= 128) {
+        if(ord($val[$i]) >= 128) {
           $utf16 = true;
           break;
         }


### PR DESCRIPTION
Issues with PHP 8.x and curly brackets being deprecated.  Tested on Server 2019 w/ IIS 10.0 and PHP 8.0.3